### PR TITLE
Check for autofill inputs scoped to #page_content

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Grundo's Café stamp album helper
 // @namespace    github.com/windupbird144
-// @version      0.5
+// @version      0.6
 // @description  Extend features of the stamp album on Grundo's Café
 // @author       supercow64, eleven
 // @match        https://www.grundos.cafe/stamps/album/?page_id=*

--- a/script.user.js
+++ b/script.user.js
@@ -87,7 +87,7 @@ function removePrefix(url) {
             w.addEventListener("DOMContentLoaded", () => {
                 const document = w.document
                 for (let [name, value] of Object.entries(formFields)) {
-                    const formField = document.querySelector(`[name='${name}']`)
+                    const formField = document.querySelector(`#page_content [name='${name}']`)
                     if (formField) {
                         formField.value = value
                     }


### PR DESCRIPTION
The updated searchbar stole `name=query` - quick little fix to ensure the TP input gets targeted