### PR TITLE
Add page Bug Collecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Credits:
 Modelled after the userscript [Stamp album helper](https://www.reddit.com/r/neopets/comments/ldrb2d/userscript_stamp_album_helper_i_made_this_tool/) by [u/Eat_Wooloo_As_Mutton](https://www.reddit.com/user/Eat_Wooloo_As_Mutton/) which was made for retail neo.
 
 
-### Developing the script
+## Developing the script
 
 
 This repository includes a Caddyfile for convenience. With caddy installed, `caddy run` can be used to host the userscript and the stamps database on `http://localhost:8080`.
@@ -36,11 +36,11 @@ localStorage.removeItem("stamp_database")
 
 
 
-### Adding a new stamp album
+## Adding a new stamp album
 - Add a new entry to `stamps.json`
 - Increment the minor version in `script.user.js`
 
-### Getting the information 
+### Getting the information from Jellyneo
 
 The information can be retrieved from various places
 
@@ -70,3 +70,30 @@ Below is a script that can be used in the browser console on Jellyneo to retriev
   return [name,rarity,description,img]
 })()
 ```
+
+### Getting the information from Grundo's Café
+
+Open a stamp album on the page you wish to scrape. Run the following
+script in the browser console. A JSON string is printed, which you can
+merge into the stamps.json file of this project.
+
+```javascript
+(function() {
+    const pageId = new URLSearchParams(window.location.search).get('page_id')
+    const cells = document.querySelectorAll("#stamp_tbl > tbody:first-of-type > tr > td")
+    const stamps = Array.from(cells).map((cell) => {
+        const img = cell.querySelector('img')
+        const imgUrl = new URL(img.src).pathname.replace('/items/', '')
+        const name = img.alt
+        return [name, -1, '???', imgUrl]
+    })
+    const stampsObject = {
+        [pageId] : stamps
+    }
+    return JSON.stringify(stampsObject, null, 2)
+})()
+```
+
+Only the name and image are available. To find out the rarity and
+description of the item, look up the item name in the item search
+of Grundo's café.

--- a/script.user.js
+++ b/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Grundo's Café stamp album helper
 // @namespace    github.com/windupbird144
-// @version      0.10
+// @version      0.11
 // @description  Extend features of the stamp album on Grundo's Café
 // @author       supercow64, eleven, rowanberryyyy, kateslines
 // @match        https://www.grundos.cafe/stamps/album/?page_id=*

--- a/script.user.js
+++ b/script.user.js
@@ -63,10 +63,7 @@ function removePrefix(url) {
             // This identifies if we have a stamp, wheteher it is collected and a database entry
             const cell = cells[slot]
             const collected = cell.title
-            let databaseEntry = database[page] ? database[page][slot] : undefined
-            if (!databaseEntry[0]) {
-                databaseEntry = undefined
-            }
+            const databaseEntry = database[page]?.[slot]?.[0] ? database[page][slot] : undefined
             // Update the dataset for the shop wizard functionality
             if (databaseEntry) {
                 cell.dataset.position = slot

--- a/script.user.js
+++ b/script.user.js
@@ -63,7 +63,10 @@ function removePrefix(url) {
             // This identifies if we have a stamp, wheteher it is collected and a database entry
             const cell = cells[slot]
             const collected = cell.title
-            const databaseEntry = database[page] ? database[page][slot] : undefined
+            let databaseEntry = database[page] ? database[page][slot] : undefined
+            if (!databaseEntry[0]) {
+                databaseEntry = undefined
+            }
             // Update the dataset for the shop wizard functionality
             if (databaseEntry) {
                 cell.dataset.position = slot
@@ -352,6 +355,7 @@ function removePrefix(url) {
             // regex to get all stamp images on this html page
             // match(/src="\/images.+?"/g).map(e => e.match(/\/images.+\.\w+/)[0])
             for (let cell of cells) {
+                if (!cell.dataset.name) continue
                 cell.parentElement.dataset.diff = ""
                 const have = cell.dataset.collected === "true"
                 const otherHas = html.includes(removePrefix(cell.src))

--- a/stamps.json
+++ b/stamps.json
@@ -2888,7 +2888,7 @@
     [
       "Sapphire Flutterfly",
       -1,
-      "???",
+      "",
       "bluemorph_stamp.gif"
     ],
     [
@@ -2906,20 +2906,20 @@
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ],
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ],
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ],
     [
       "Uncommon Blue Collectable Scarab",
@@ -2936,8 +2936,8 @@
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ],
     [
       "Greater Green Collectable Scarab",
@@ -2948,8 +2948,8 @@
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ],
     [
       "Kreludor Moth",
@@ -2972,8 +2972,8 @@
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ],
     [
       "Trilo Bite Beetle",
@@ -2990,8 +2990,8 @@
     [
       "",
       -1,
-      "???",
-      "/misc/no_stamp.gif"
+      "",
+      ""
     ]
   ]
 }

--- a/stamps.json
+++ b/stamps.json
@@ -2841,5 +2841,157 @@
         "Wow, that is a big foot!",
         "footprint_fossil.gif"
     ]
+  ],
+  "47": [
+    [
+      "Empty Husk",
+      101,
+      "Just an empty husk.",
+      "cicadahusk_stamp.gif"
+    ],
+    [
+      "Neohome Fly",
+      101,
+      "Ever wonder what was in Fantastic Fly Pie?",
+      "housefly_stamp.gif"
+    ],
+    [
+      "Lacewing",
+      101,
+      "Look at its beautiful delicate wings.",
+      "lacewing_stamp.gif"
+    ],
+    [
+      "Common Desert Collectable Scarab",
+      85,
+      "This fancy scarab has an ornamental design.",
+      "coi_desertscarab_slim.gif"
+    ],
+    [
+      "Noisy Sheeshoo Bug",
+      101,
+      "Some love the noise they make! No idea why though.",
+      "cicada_stamp.gif"
+    ],
+    [
+      "Taffi Moth",
+      101,
+      "Probably don't eat it.",
+      "roseymaplemoth_stamp.gif"
+    ],
+    [
+      "Basic Fringed Collectable Scarab",
+      89,
+      "This scarab is covered in a fancy fringe!",
+      "coi_scarab_4.gif"
+    ],
+    [
+      "Sapphire Flutterfly",
+      -1,
+      "???",
+      "bluemorph_stamp.gif"
+    ],
+    [
+      "Simple Red Collectable Scarab",
+      101,
+      "With wings that glisten like... a sapphire!",
+      "coi_red_scarabs.gif"
+    ],
+    [
+      "Elegant Moth",
+      101,
+      "Look at this lovely lady.",
+      "whitemoth_stamp.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ],
+    [
+      "Uncommon Blue Collectable Scarab",
+      95,
+      "You won't see this scarab often so make sure you get it when you see it!",
+      "coi_scarab_3.gif"
+    ],
+    [
+      "Spotted Longhorn Beetle",
+      101,
+      "Are they antennas or horns?",
+      "longhorn_stamp.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ],
+    [
+      "Greater Green Collectable Scarab",
+      93,
+      "This beautiful green scarab has a fascinating pattern on its back that is quite hypnotising.",
+      "coi_desertscarab_green.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ],
+    [
+      "Kreludor Moth",
+      101,
+      "Some say their bushy antennae are for receiving signals from Dr. Sloth.",
+      "lunamoth_stamp.gif"
+    ],
+    [
+      "Stick Bug",
+      101,
+      "Are we sure this is actually a bug and not a stick?",
+      "stickbug_stamp.gif"
+    ],
+    [
+      "Spotted Red Collectable Scarab",
+      96,
+      "The spots on this Scarabs back scare away its enemies!",
+      "coi_dotted_scarabs.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ],
+    [
+      "Trilo Bite Beetle",
+      101,
+      "This beetle is almost as old as Tyrannia!",
+      "platerodrilus_stamp.gif"
+    ],
+    [
+      "Magmara Moth",
+      101,
+      "This is a giant! Among bugs, at least.",
+      "atlasmoth_stamp.gif"
+    ],
+    [
+      "",
+      -1,
+      "???",
+      "/misc/no_stamp.gif"
+    ]
   ]
 }


### PR DESCRIPTION
Fixes #5 

This merge request adds the missing information on collectable bugs to the stamp database. The names and images of the remaining bugs is known, but their position in the album is not. So they are left blank. This is the first album page for which we only have information on some stamps. That's why this merge request also adds some code to address stamps missing from the database, notably an if-condition when populating the page and a continue in the diff with another user.

![screenie](https://github.com/user-attachments/assets/acd018df-3146-4971-a62c-28e57f4d68ab)
